### PR TITLE
Add a sample settingspage

### DIFF
--- a/samples/MvvmSample.Core/Services/ISettingsService.cs
+++ b/samples/MvvmSample.Core/Services/ISettingsService.cs
@@ -12,6 +12,10 @@ namespace MvvmSample.Core.Services
     /// </summary>
     public interface ISettingsService
     {
+        bool BoolSampleSetting { get; set; }
+
+        bool BoolSampleSetting2 { get; set; }
+
         /// <summary>
         /// Assigns a value to a settings key.
         /// </summary>

--- a/samples/MvvmSample.Core/ViewModels/SettingsPageViewModel.cs
+++ b/samples/MvvmSample.Core/ViewModels/SettingsPageViewModel.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using MvvmSample.Core.Services;
+
+namespace MvvmSample.Core.ViewModels
+{
+    /// <summary>
+    /// The ViewModel for the SettingsPage.
+    /// </summary>
+    public class SettingsPageViewModel : ObservableObject
+    {
+        /// <summary>
+        /// Gets the <see cref="ISettingsService"/> instance to use.
+        /// </summary>
+        private readonly ISettingsService SettingsService = Ioc.Default.GetRequiredService<ISettingsService>();
+
+
+        public SettingsPageViewModel()
+        {
+
+        }
+
+        /// <summary>
+        /// A sample boolean settingsvalue bound to the UI
+        /// </summary>
+        public bool BoolSetting
+        {
+            get => SettingsService.BoolSampleSetting;
+            set => SettingsService.BoolSampleSetting = value;
+        }
+
+        /// <summary>
+        /// A sample boolean settingsvalue bound to the UI
+        /// </summary>
+        public bool BoolSetting2
+        {
+            get => SettingsService.BoolSampleSetting2;
+            set => SettingsService.BoolSampleSetting2 = value;
+        }
+
+    }
+}
+

--- a/samples/MvvmSampleUwp/MvvmSampleUwp.csproj
+++ b/samples/MvvmSampleUwp/MvvmSampleUwp.csproj
@@ -140,6 +140,9 @@
     <Compile Include="Views\SettingsServicePage.xaml.cs">
       <DependentUpon>SettingsServicePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\SettingsPage.xaml.cs">
+      <DependentUpon>SettingsPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SettingUpTheViewModelsPage.xaml.cs">
       <DependentUpon>SettingUpTheViewModelsPage.xaml</DependentUpon>
     </Compile>
@@ -287,6 +290,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\SettingsServicePage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\SettingsPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/samples/MvvmSampleUwp/Services/SettingsService.cs
+++ b/samples/MvvmSampleUwp/Services/SettingsService.cs
@@ -35,5 +35,20 @@ namespace MvvmSampleUwp.Services
 
             return default;
         }
+
+
+        public bool BoolSampleSetting
+        {
+            get => GetValue<bool>(nameof(BoolSampleSetting));
+            set => SetValue<bool>(nameof(BoolSampleSetting), value);
+        }
+
+        public bool BoolSampleSetting2
+        {
+            get => GetValue<bool>(nameof(BoolSampleSetting2));
+            set => SetValue<bool>(nameof(BoolSampleSetting2), value);
+        }
+
+
     }
 }

--- a/samples/MvvmSampleUwp/Shell.xaml
+++ b/samples/MvvmSampleUwp/Shell.xaml
@@ -25,7 +25,7 @@
             x:Name="NavigationView"
             IsTitleBarAutoPaddingEnabled="False"
             IsBackEnabled="False"
-            IsSettingsVisible="False"
+            IsSettingsVisible="True"
             ItemInvoked="NavigationView_OnItemInvoked"
             BackRequested="NavigationView_OnBackRequested">
 

--- a/samples/MvvmSampleUwp/Shell.xaml.cs
+++ b/samples/MvvmSampleUwp/Shell.xaml.cs
@@ -51,9 +51,16 @@ namespace MvvmSampleUwp
         // Navigates to a sample page when a button is clicked
         private void NavigationView_OnItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
         {
-            if (NavigationItems.FirstOrDefault(item => item.Item == args.InvokedItemContainer)?.PageType is Type pageType)
+            if (args.IsSettingsInvoked)
             {
-                NavigationFrame.Navigate(pageType);
+                NavigationFrame.Navigate(typeof(SettingsPage));
+            }
+            else
+            {
+                if (NavigationItems.FirstOrDefault(item => item.Item == args.InvokedItemContainer)?.PageType is Type pageType)
+                {
+                    NavigationFrame.Navigate(pageType);
+                }
             }
         }
 

--- a/samples/MvvmSampleUwp/Views/SettingsPage.xaml
+++ b/samples/MvvmSampleUwp/Views/SettingsPage.xaml
@@ -1,0 +1,59 @@
+﻿<Page
+    x:Class="MvvmSampleUwp.Views.SettingsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:viewModels="using:MvvmSample.Core.ViewModels"
+    xmlns:core="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
+    <Page.DataContext>
+        <viewModels:SettingsPageViewModel x:Name="ViewModel"/>
+    </Page.DataContext>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+       
+        <StackPanel Grid.Row="0">
+            <TextBlock 
+                   FontSize="24"
+                   Text="Settings"
+                   TextWrapping="WrapWholeWords"
+                   Margin="16,16,16,0"/>
+            <TextBlock
+                   FontSize="14"
+                   TextWrapping="WrapWholeWords"
+                   Margin="16,0,16,16">
+                <Hyperlink NavigateUri="https://docs.microsoft.com/en-us/windows/apps/design/app-settings/guidelines-for-app-settings">
+                    https://docs.microsoft.com/en-us/windows/apps/design/app-settings/guidelines-for-app-settings
+                </Hyperlink>
+            </TextBlock>
+        </StackPanel>
+        
+        <ScrollViewer Grid.Row="1" 
+                      Padding="16" 
+                      CanContentRenderOutsideBounds="True">
+            <StackPanel>
+                <ToggleSwitch x:Name="BoolSampleSettingToggle" 
+                              Header="BoolSampleSetting"
+                              Margin="16"
+                              IsOn="{Binding BoolSetting, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              />
+
+                <ToggleSwitch x:Name="BoolSampleSettingToggle2"
+                              Header="BoolSampleSetting2"
+                              Margin="16" 
+                              IsOn="{Binding BoolSetting2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            </StackPanel>
+
+        </ScrollViewer>
+    </Grid>
+    
+   
+</Page>

--- a/samples/MvvmSampleUwp/Views/SettingsPage.xaml.cs
+++ b/samples/MvvmSampleUwp/Views/SettingsPage.xaml.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.UI.Xaml.Controls;
+
+namespace MvvmSampleUwp.Views
+{
+    /// <summary>
+    /// An sample app settings page.
+    /// </summary>
+    public sealed partial class SettingsPage : Page
+    {
+        public SettingsPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Adds a sample appsettings page, since this was missing and settings have a specific way to be invoked that is different from other navigation items.  